### PR TITLE
setup: fix readme path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ from setuptools import setup, find_packages
     
 here = path.abspath(path.dirname(__file__))
 
-with open(path.join(here, 'README'), encoding = 'utf-8') as f:
+with open(path.join(here, 'README.md'), encoding = 'utf-8') as f:
     long_description = f.read()
     
 


### PR DESCRIPTION
I got this on `pip install -e .`
```
pip install -e .
Obtaining file:///usr/home/iblis/git/concurrent_ap
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/usr/home/iblis/git/concurrent_ap/setup.py", line 44, in <module>
        with open(path.join(here, 'README'), encoding = 'utf-8') as f:
      File "/usr/local/lib/python3.6/codecs.py", line 895, in open
        file = builtins.open(filename, mode, buffering)
    FileNotFoundError: [Errno 2] No such file or directory: '/usr/home/iblis/git/concurrent_ap/README'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /usr/home/iblis/git/concurrent_ap/
```