### PR TITLE
Replace sklearn euclidean import with custom function

### DIFF
--- a/Concurrent_AP.py
+++ b/Concurrent_AP.py
@@ -41,7 +41,6 @@ import numpy as np
 import optparse
 import os
 import psutil
-from sklearn.metrics.pairwise import euclidean_distances
 import sys
 import tables
 from tempfile import NamedTemporaryFile
@@ -54,6 +53,11 @@ warnings.filterwarnings('ignore', category = DeprecationWarning)
 
 __all__ = []
 
+def euclidean_distances(x, y, squared=False):
+    if squared:
+        return np.dot(x,x) - 2 * np.dot(x,y) + np.dot(y, y)
+    else: 
+        return np.sqrt(np.dot(x,x) - 2 * np.dot(x,y) + np.dot(y, y))
 
 def memory():
     """Determine memory specifications of the machine.

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(name = 'Concurrent_AP',
       
       py_modules = ['Concurrent_AP'],
       platforms = ('Any',),
-      install_requires = ['numpy>=1.9.0', 'psutil', 'sklearn', 'setuptools', 'tables'],
+      install_requires = ['numpy>=1.9.0', 'psutil', 'setuptools', 'tables'],
                           
       classifiers = ['Development Status :: 4 - Beta',
                    'Environment :: Console',


### PR DESCRIPTION
euclidean distance is the only function that is imported from sklearn, and its a trivial function to define for ourselves. Lets remove the sklearn import and instead just use a custom euclidean function. 